### PR TITLE
Fix for Typescript 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@types/node": "^8.0.19",
-    "typescript": "^2.4.2",
+    "typescript": "^4.1.2",
     "body-parser": "^1.17"
   },
   "scripts": {

--- a/src/kumoServer.ts
+++ b/src/kumoServer.ts
@@ -8,7 +8,7 @@ const bodyParser = require('body-parser')
 const app = express()
 
 const SKumo = require('./kumojs').Kumo;
-const Scfg = require('./kumo.cfg');
+const Scfg = require(process.cwd() + '/kumo.cfg');
 var kumo = new SKumo(Scfg);
 
 
@@ -182,7 +182,7 @@ app.listen(port, function () {
 })
 
 const sleep = (ms: number) => {
-    return new Promise((resolve) => {
+    return new Promise<void>((resolve) => {
         setTimeout(() => {
             resolve();
         }, ms);

--- a/src/kumojs.ts
+++ b/src/kumojs.ts
@@ -57,9 +57,9 @@ export class Kumo {
             sjcl.hash.sha256.hash(
                 sjcl.codec.hex.toBits(
                     this.l2h(
-                        Array.prototype.map.call(p+dt, function (m2:any) {
+                        Array.prototype.map.call(p+dt, function (m2:String) {
                             return m2.charCodeAt(0)
-                        })
+                        }) as number[]
                     )
                 )
             )
@@ -72,7 +72,7 @@ export class Kumo {
         let dt3 = this.h2l(dt2)
         dt3[64] = 8
         dt3[65] = 64
-        Array.prototype.splice.apply(dt3, [32, 32].concat(dt1_l));
+        dt3.splice(32, 32, ...dt1_l)
         dt3[66] =  cfg.S
         let cryptoserial = this.h2l(cfg['cryptoSerial'])
         dt3[79] = cryptoserial[8]
@@ -84,7 +84,7 @@ export class Kumo {
         dt3[85] = cryptoserial[1]
         dt3[86] = cryptoserial[2]
         dt3[87] = cryptoserial[3]
-        Array.prototype.splice.apply(dt3, [0, 32].concat(W))
+        dt3.splice(0, 32, ...W)
         let hash = sjcl.codec.hex.fromBits(
             sjcl.hash.sha256.hash(sjcl.codec.hex.toBits(this.l2h(dt3)))
         )
@@ -120,7 +120,7 @@ export class Kumo {
                 });
         });
     }
-    private timeout(ms: Number): Promise <any> {
+    private timeout(ms: number): Promise <any> {
       return new Promise(resolve => setTimeout(resolve, ms));
     }
     public async cmd(address: string, pdata:string): Promise<any> {


### PR DESCRIPTION
### Description

The current code uses an old version of Typescript - and at least when I tried to build it locally this seemed to conflict with my local environment (even after trying `npm install -g typescript@2`). 

I just fixed the code to work with Typescript 4+ by modifying a few types + `splice`s.

Should resolve https://github.com/sushilks/kumojs/issues/4 too.

Note: Not 100% on the `process.cwd()` fix - but certainly when I was running locally the previous `./` was looking in the same directory as the script, not the working directory where `kumoconfig` generated the `.cfg`.

### Testing

Tested with local AC:

```
curl http://127.0.0.1:8084/v0/room/Bedroom/status
{"r":{"indoorUnit":{"status":{"roomTemp":26,"mode":"heat","spCool":24,"spHeat":21,"vaneDir":"auto","fanSpeed":"auto","tempSource":"unset","activeThermistor":"unset","filterDirty":false,"hotAdjust":false,"defrost":false,"standby":false,"runTest":0}}}}⏎
```