### PR TITLE
make it possible to get config by passing environment variables

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,12 +4,13 @@
   "author": "Sushil Singh",
   "description": "Api Gateway and Controller for Mitsubishi Airconditioners",
   "dependencies": {
-    "express": "^4.15.4",
-    "source-map-support": "^0.4.16",
     "base-64": "^0.1",
-    "request": "",
+    "dotenv": "^10.0.0",
+    "express": "^4.15.4",
     "neodoc": "",
-    "sjcl": "^1.0"
+    "request": "",
+    "sjcl": "^1.0",
+    "source-map-support": "^0.4.16"
   },
   "devDependencies": {
     "@types/node": "^8.0.19",


### PR DESCRIPTION
The config command will look for environment variables `KUMO_USER` and `KUMO_PASS`. They can also be specified in a `.env` file placed in the project root.

If the environment variables are not found, it goes back to the old behaviour of prompting the user.

This feature makes it easier to run non-interactively, e.g. in a docker setup script.